### PR TITLE
Rename the :name attribute in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gs",
+  "name": "nypl-cloudwatch-alarm-mailer",
   "version": "1.0.0",
   "description": "Subscribes to SNS messages (from alarms), gets relevant log lines, emails them.",
   "main": "index.js",


### PR DESCRIPTION
Since the lambda name defaults to this value almost anything is better than 'gs'.

@rhernand3z, how do you feel about "nypl-alarm-mailer"?
Is that a good name 'nypl-cloudwatch-alarm-mailer'? Is that too big?
Ultimately, **I'd be game for renaming the repo to the name we decide on.**

 
